### PR TITLE
Live Refresh on Edit

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,46 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "make run"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html", "scss"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ public/css/*.scss.css
 .myradio.key
 config.toml
 public/css/*.scss.css.map
+tmp/build-errors.log

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# 201623-site #
+# 201623-site
 
-## How to install ##
+## How to install
+
 Full instructions for installation are available in the USING.md file.
 If you already know what you're doing, the instructions below should suffice.
 
@@ -10,26 +11,66 @@ requisite permissions copied into a .myradio.key file in the same directory.
 
 Then follow the Requirements below.
 
-## Requirements ##
+## Requirements
+
 Requires [Go 1.6](https://golang.org/) to compile and run, along with `sassc` to
 compile the SCSS files. You may use other SASS compilers if you wish, but be
 prepared for unexpected results.
 
 Alternatively, you can use Docker alone
 
-## Running the site ##
+## Running the site
 
-### Without Docker ###
+### Without Docker
+
 ```bash
 $ make run # Builds scss files, and runs the server
 ```
 
-### With Docker :whale: ###
+### With Docker :whale:
+
 ```bash
 $ make build-docker-image #Builds the image, will only have to be re-run if you change the Dockerfile
 $ make docker #Runs the image
 ```
 
-
 ## Editor Config
+
 There is a handy editor config file included in this repo, most editors/IDE's have support for this either natively or through a plugin, see [here](http://editorconfig.org/#download).
+
+## With Air (Live Refresh)
+
+Air is a tool for live rebuilding on file edits, saving you having to manually kill and restart the running local server whenever you edit the Go or SCSS. An air config file for rebuilding the Go ans SCSS is included with this project
+
+### Install Air
+
+```bash
+$ go install github.com/cosmtrek/air@latest
+```
+
+You may also have to manually set up the alias for it to run properly
+
+```bash
+$ alias air='$(go env GOPATH)/bin/air'
+```
+
+Once you've done this, you can just run:
+
+```bash
+$ air
+```
+
+and this should set up a live refreshing dev environment
+
+### XDOTOOL for live browser refresh
+
+Also included in this project is an XDOTOOL script for auto refreshing the browser when a change is made, this script is disabled by default as it only currently works on X11/Linux and requires a little setup.
+
+First, install `XDOTOOL`, then, replace the line in .air.toml
+` cmd = "make run"`
+with
+`cmd = "sh liverefresh.sh"`
+
+The script is currently configured to work with Firefox, however, for other browsers, edit the line
+`WID=$(xdotool search --name "Mozilla Firefox")`
+to include your browser of choice

--- a/liverefresh.sh
+++ b/liverefresh.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#This script will only work on Linux (Specifically using X11)
+CURRENT_WID=$(xdotool getwindowfocus)
+
+WID=$(xdotool search --name "Mozilla Firefox")
+xdotool windowactivate $WID
+xdotool key F5
+
+xdotool windowactivate $CURRENT_WID
+make run


### PR DESCRIPTION
Adds facilities for live rebuilding and refreshing the website on file edit for development.

(The tool for live refreshing the browser is rather janky and limited at the moment, this should probably later by replaced with a websocket integration)